### PR TITLE
papyrus_ogcproxy.views.ogcproxy cleanup

### DIFF
--- a/papyrus_ogcproxy/views.py
+++ b/papyrus_ogcproxy/views.py
@@ -23,10 +23,9 @@ allowed_hosts = (
     )
 
 def ogcproxy(request):
-    if "url" not in request.params:
+    url = request.params.get("url")
+    if url is None:
         return HTTPBadRequest()
-
-    url = request.params["url"]
 
     # check for full url
     parsed_url = urlparse(url)


### PR DESCRIPTION
Hello,
Two small update:
- use request.params.get to get the 'url' value (avoid double access to the dict).
- don't check request.body; simply pass the value to http.request (with GET, the request.body is an empty string)
