### PR TITLE
Disable SSL certificate validation

### DIFF
--- a/papyrus_ogcproxy/views.py
+++ b/papyrus_ogcproxy/views.py
@@ -33,7 +33,7 @@ def ogcproxy(request):
         return HTTPBadRequest()
 
     # forward request to target (without Host Header)
-    http = Http()
+    http = Http(disable_ssl_certificate_validation=True)
     h = dict(request.headers)
     h.pop("Host", h)
     try:


### PR DESCRIPTION
With swisstopo WMS the requests will be done through https, this is an easy way to make GetFeatureInfo work throw the ogcproxy.
