### PR TITLE
Support proxies for proxy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ file.
 Set up
 ------
 
-Using papyrus_ogcproxy to set an OGC proxy in a Pyramid application is easy.
+Using papyrus_ogcproxy to set up an OGC proxy in a Pyramid application is easy.
 
 Edit the application's main file, ``__init__.py``, and register
 papyrus_ogcproxy using the ``Configurator.include`` method::
@@ -38,12 +38,45 @@ papyrus_ogcproxy using the ``Configurator.include`` method::
 That's it! The OGC proxy is available at ``/ogcproxy``.
 
 Here is a test URL:
-http://localhost:6543/ogcproxy?url=http%3A%2F%2Fwms.jpl.nasa.gov%2Fwms.cgi%3FSERVICE%3DWMS%26REQUEST%3DGetCapabilities
+http://localhost:6543/ogcproxy?url=http%3A%2F%2Fmap1.vis.earthdata.nasa.gov/wmts-geo/wmts.cgi%3FSERVICE%3DWMTS%26REQUEST%3DGetCapabilities
+
+Using a proxy for the proxy
+---------------------------
+
+If the requests made by the OGC proxy should be made through a proxy, the additional
+package ``pysocks`` is required. After the installation of this package, configure
+the proxy::
+
+
+    from papyrus_ogcproxy import views as ogcproxy_views
+    from httplib2 import ProxyInfo
+    import socks
+    ogcproxy_views.proxy_info = ProxyInfo(socks.SOCKS5, 'localhost', 1080)
+
+With this configuration the OGC proxy will make requests through the proxy
+``localhost:1080``. For information please refer to the
+documentation of `PySocks <https://github.com/Anorov/PySocks>`_ and
+`httplib2 <http://httplib2.googlecode.com/hg/doc/html/libhttplib2.html#httplib2.ProxyInfo>`_.
+
+
+Set up a development environment
+--------------------------------
+
+To set up a development environment with virtualenv, run the following
+commands::
+
+    $ virtualenv venv
+    $ venv/bin/python setup.py develop
+    $ venv/bin/pip install -r requirements-dev.txt
 
 Run the tests
 -------------
 
-To run the tests install the ``nose``, ``mock`` and ``coverage`` packages in
-the Python environment, and execute::
+To run the tests::
 
-    $ nosetests --with-coverage
+    $ venv/bin/nosetests --with-coverage
+
+One test assumes that a proxy server is running at ``localhost:1080``. To start
+a proxy run::
+
+    $ ssh -N -D 0.0.0.0:1080 localhost

--- a/papyrus_ogcproxy/tests/tests.py
+++ b/papyrus_ogcproxy/tests/tests.py
@@ -44,6 +44,7 @@ class OgcProxy(unittest.TestCase):
         testing.tearDown()
         from papyrus_ogcproxy import views
         views.allowed_hosts = ()
+        views.proxy_info = None
 
     def test_badrequest_url(self):
         from papyrus_ogcproxy.views import ogcproxy
@@ -126,3 +127,26 @@ class OgcProxy(unittest.TestCase):
         self.assertTrue(isinstance(response, Response))
         self.assertEqual(response.status_int, 200)
         self.assertEqual(response.content_type, 'text/xml')
+
+    def test_proxy_info(self):
+        """ Running this test assumes that a proxy is running at localhost:1080.
+        To start a proxy run:
+
+            ssh -N -D 0.0.0.0:1080 localhost
+
+        """
+        from papyrus_ogcproxy import views
+        from papyrus_ogcproxy.views import ogcproxy
+        from pyramid.testing import DummyRequest
+        from httplib2 import ProxyInfo
+        import socks
+
+        views.allowed_hosts = ('www.google.com')
+        views.proxy_info = ProxyInfo(socks.SOCKS5, 'localhost', 1080)
+        request = DummyRequest(scheme='http',
+                               params={'url': 'http://www.google.com'})
+        response = ogcproxy(request)
+        from pyramid.response import Response
+        self.assertTrue(isinstance(response, Response))
+        self.assertEqual(response.status_int, 200)
+        self.assertEqual(response.content_type, 'text/html')

--- a/papyrus_ogcproxy/tests/tests.py
+++ b/papyrus_ogcproxy/tests/tests.py
@@ -118,11 +118,11 @@ class OgcProxy(unittest.TestCase):
     def test_allowed_content_type(self):
         from papyrus_ogcproxy.views import ogcproxy
         from pyramid.testing import DummyRequest
-        url = 'http://wms.jpl.nasa.gov/wms.cgi?' \
-                  'SERVICE=WMS&REQUEST=GetCapabilities'
+        url = 'http://map1.vis.earthdata.nasa.gov/wmts-geo/wmts.cgi?' \
+              'SERVICE=WMTS&REQUEST=GetCapabilities'
         request = DummyRequest(scheme='http', params={'url': url})
         response = ogcproxy(request)
         from pyramid.response import Response
         self.assertTrue(isinstance(response, Response))
         self.assertEqual(response.status_int, 200)
-        self.assertEqual(response.content_type, 'application/vnd.ogc.wms_xml')
+        self.assertEqual(response.content_type, 'text/xml')

--- a/papyrus_ogcproxy/views.py
+++ b/papyrus_ogcproxy/views.py
@@ -22,6 +22,13 @@ allowed_hosts = (
     # list allowed hosts here (no port limiting)
     )
 
+# The proxy to use to make requests (default: None).
+#
+# Example usage:
+#   views.proxy_info = ProxyInfo(socks.SOCKS5, 'localhost', 1080)
+#
+proxy_info = None
+
 def ogcproxy(request):
     url = request.params.get("url")
     if url is None:
@@ -33,7 +40,9 @@ def ogcproxy(request):
         return HTTPBadRequest()
 
     # forward request to target (without Host Header)
-    http = Http(disable_ssl_certificate_validation=True)
+    http = Http(
+        disable_ssl_certificate_validation=True,
+        proxy_info=proxy_info)
     h = dict(request.headers)
     h.pop("Host", h)
     try:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+nose
+mock
+coverage
+pysocks


### PR DESCRIPTION
With this PR, requests made by the OGC proxy can now be made through a proxy. To use a proxy, the additional package [PySocks](https://github.com/Anorov/PySocks) has to be installed.

Example configuration:

    from papyrus_ogcproxy import views as ogcproxy_views
    from httplib2 import ProxyInfo
    import socks
    ogcproxy_views.proxy_info = ProxyInfo(socks.SOCKS5, 'localhost', 1080)